### PR TITLE
feat: Add form to customise quiz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "react-boilerplate-app",
       "version": "0.1.0",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "@mui/material": "^6.3.1",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.9",
         "@tailwindcss/line-clamp": "^0.4.4",
@@ -1951,9 +1954,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2286,6 +2289,163 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3197,6 +3357,213 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.3.1.tgz",
+      "integrity": "sha512-2OmnEyoHpj5//dJJpMuxOeLItCCHdf99pjMFfUFdBteCunAK9jW+PwEo4mtdGcLs7P+IgZ+85ypd52eY4AigoQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.3.1.tgz",
+      "integrity": "sha512-ynG9ayhxgCsHJ/dtDcT1v78/r2GwQyP3E0hPz3GdPRl0uFJz/uUTtI5KFYwadXmbC+Uv3bfB8laZ6+Cpzh03gA==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/core-downloads-tracker": "^6.3.1",
+        "@mui/system": "^6.3.1",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.3.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material-pigment-css": "^6.3.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.3.1.tgz",
+      "integrity": "sha512-g0u7hIUkmXmmrmmf5gdDYv9zdAig0KoxhIQn1JN8IVqApzf/AyRhH3uDGx5mSvs8+a1zb4+0W6LC260SyTTtdQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/utils": "^6.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.3.1.tgz",
+      "integrity": "sha512-/7CC0d2fIeiUxN5kCCwYu4AWUDd9cCTxWCyo0v/Rnv6s8uk6hWgJC3VLZBoDENBHf/KjqDZuYJ2CR+7hD6QYww==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.3.1.tgz",
+      "integrity": "sha512-AwqQ3EAIT2np85ki+N15fF0lFXX1iFPqenCzVOSl3QXKy2eifZeGd9dGtt7pGMoFw5dzW4dRGGzRpLAq9rkl7A==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.3.1",
+        "@mui/styled-engine": "^6.3.1",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.3.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.21",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
+      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-sjGjXAngoio6lniQZKJ5zGfjm+LD2wvLwco7FbKe1fu8A7VIFmz2SwkLb+MDPLNX1lE7IscvNNyh1pobtZg2tw==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "^7.2.21",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3311,6 +3678,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -4363,10 +4739,9 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/q": {
       "version": "1.5.8",
@@ -4387,7 +4762,6 @@
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4399,6 +4773,14 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -6081,6 +6463,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6691,8 +7081,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7021,6 +7410,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -8462,6 +8860,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9128,6 +9531,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -15193,6 +15609,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -16565,6 +16996,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -19886,9 +20322,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -20064,6 +20500,137 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
       "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "requires": {}
+    },
+    "@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+          "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+        }
+      }
+    },
+    "@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "requires": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "requires": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+    },
+    "@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "requires": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+    },
+    "@emotion/styled": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+    },
+    "@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "requires": {}
+    },
+    "@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -20722,6 +21289,101 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
+    "@mui/core-downloads-tracker": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.3.1.tgz",
+      "integrity": "sha512-2OmnEyoHpj5//dJJpMuxOeLItCCHdf99pjMFfUFdBteCunAK9jW+PwEo4mtdGcLs7P+IgZ+85ypd52eY4AigoQ=="
+    },
+    "@mui/material": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.3.1.tgz",
+      "integrity": "sha512-ynG9ayhxgCsHJ/dtDcT1v78/r2GwQyP3E0hPz3GdPRl0uFJz/uUTtI5KFYwadXmbC+Uv3bfB8laZ6+Cpzh03gA==",
+      "requires": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/core-downloads-tracker": "^6.3.1",
+        "@mui/system": "^6.3.1",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.3.1",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+          "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
+        }
+      }
+    },
+    "@mui/private-theming": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.3.1.tgz",
+      "integrity": "sha512-g0u7hIUkmXmmrmmf5gdDYv9zdAig0KoxhIQn1JN8IVqApzf/AyRhH3uDGx5mSvs8+a1zb4+0W6LC260SyTTtdQ==",
+      "requires": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/utils": "^6.3.1",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/styled-engine": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.3.1.tgz",
+      "integrity": "sha512-/7CC0d2fIeiUxN5kCCwYu4AWUDd9cCTxWCyo0v/Rnv6s8uk6hWgJC3VLZBoDENBHf/KjqDZuYJ2CR+7hD6QYww==",
+      "requires": {
+        "@babel/runtime": "^7.26.0",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/system": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.3.1.tgz",
+      "integrity": "sha512-AwqQ3EAIT2np85ki+N15fF0lFXX1iFPqenCzVOSl3QXKy2eifZeGd9dGtt7pGMoFw5dzW4dRGGzRpLAq9rkl7A==",
+      "requires": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/private-theming": "^6.3.1",
+        "@mui/styled-engine": "^6.3.1",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.3.1",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/types": {
+      "version": "7.2.21",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
+      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
+      "requires": {}
+    },
+    "@mui/utils": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-sjGjXAngoio6lniQZKJ5zGfjm+LD2wvLwco7FbKe1fu8A7VIFmz2SwkLb+MDPLNX1lE7IscvNNyh1pobtZg2tw==",
+      "requires": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "^7.2.21",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+          "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
+        }
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -20788,6 +21450,11 @@
         "schema-utils": "^4.2.0",
         "source-map": "^0.7.3"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -21550,10 +22217,9 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "@types/q": {
       "version": "1.5.8",
@@ -21574,7 +22240,6 @@
       "version": "18.3.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -21588,6 +22253,12 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "requires": {}
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -22814,6 +23485,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -23236,8 +23912,7 @@
     "csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -23477,6 +24152,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -24549,6 +25233,11 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -24990,6 +25679,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -29086,6 +29790,17 @@
         }
       }
     },
+    "react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -30089,6 +30804,11 @@
         "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       }
+    },
+    "stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "sucrase": {
       "version": "3.35.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     ]
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
+    "@mui/material": "^6.3.1",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,43 +1,81 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import type { AnswerProps } from "./types/answer";
+import type { ApiDataProps } from "./types/triviaApi";
+import type { QueryProps } from "./types/queryOptions";
 import QuestionsList from "./components/QuestionsList/QuestionsList";
 import Button from "./components/Button/Button";
 import { getQuestions } from "./api/getQuestions";
-import { AnswerProps } from "./types/answer";
 import { useQuery } from "@tanstack/react-query";
-import { ApiDataProps } from "./types/triviaApi";
+import { INITIAL_QUERY_VALUE } from "./constants/query";
+import { delayFunctionCall } from "./utils/delayFunctionCall";
+import CustomiseTriviaForm from "./modules/CustomiseTriviaForm/CustomiseTriviaForm";
 
 function App() {
   const [ answers, setAnswers ] = useState<AnswerProps[]>([]);
+  const [ enabled, setEnabled ] = useState<boolean>(false);
+  const [ openCustomizationOptions, setOpenCustomizationOptions ] = useState<boolean>(false);
+  const [ tempQuery, setTempQuery ] = useState<QueryProps>(INITIAL_QUERY_VALUE);
+  const [ query, setQuery ] = useState<QueryProps>(INITIAL_QUERY_VALUE);
   const [ isFormSubmitted, setIsFormSubmitted ] = useState<boolean>(false);
+
   const response = useQuery<ApiDataProps>({
-    queryKey: ['triviaData'],
-    queryFn: getQuestions,
+    queryKey: ['triviaData', query],
+    queryFn: () => getQuestions(query),
+    enabled,
+    retry: 3,
+    retryDelay: 5000,
   });
+
+  useEffect(() => {
+    //Delay the first call to the api in 5 seconds to prevent "Exceeded Request Limit" error
+    delayFunctionCall(() => setEnabled(true));
+  }, []);
 
   const handleReloadClick = () => {
     setIsFormSubmitted(false);
     setAnswers([]);
+    setEnabled(true);
     response.refetch();
+  }
+
+  const handleDelayedReloadClick = () => {
+    setEnabled(false);
+    delayFunctionCall(() => handleReloadClick());
+  };
+
+  const handleOpenCustomForm = () => {
+    setOpenCustomizationOptions(true);
   }
 
   return (
     <div className="w-full h-full flex justify-center bg-mono-100" >
       <div className="w-full lg:w-3/4 h-full flex flex-col justify-center">
-        <header
-          className="bg-mono-100 w-full text-primary-900 flex justify-between items-center py-3 px-6 sticky z-100 top-0">
-          <h1 className="text-32">Trivia</h1>
-          <nav>
-            <Button onClick={ handleReloadClick }>Reload</Button>
-          </nav>
+        <header className="bg-mono-100 w-full text-primary-900 flex flex-col justify-between items-center py-3 px-6 sticky z-100 top-0">
+          <div className="flex justify-between w-full py-4">
+            <h1 className="text-32">Trivia</h1>
+            <nav className="flex gap-4 w-fuit">
+              <Button onClick={ handleOpenCustomForm }>Customise your trivia!</Button>
+              <Button disabled={!enabled} onClick={ handleDelayedReloadClick } variant = 'secondary' >Reload</Button>
+            </nav>
+          </div>
+          {openCustomizationOptions ? (
+            <CustomiseTriviaForm
+              setQuery={ setQuery }
+              setTempQuery={ setTempQuery }
+              tempQuery={ tempQuery }
+              setOpenCustomizationOptions={ setOpenCustomizationOptions }
+            />
+          ) : null }
         </header>
         <main className="w-full h-full min-h-dvh flex flex-grow justify-center items-center p-3">
           <section className="flex flex-col gap-4 items-center w-full">
             <QuestionsList
-              response={response}
-              answers={answers}
-              isFormSubmitted={isFormSubmitted}
-              setIsFormSubmitted={setIsFormSubmitted}
-              setAnswers={setAnswers}
+              enabled={enabled}
+              response={ response }
+              answers={ answers }
+              isFormSubmitted={ isFormSubmitted }
+              setIsFormSubmitted={ setIsFormSubmitted }
+              setAnswers={ setAnswers }
             />
           </section>
         </main>

--- a/src/api/getCategories.ts
+++ b/src/api/getCategories.ts
@@ -1,0 +1,12 @@
+import { ApiCategoryProps } from "../types/triviaApi";
+
+const CATEGORIES_API_URL = 'https://opentdb.com/api_category.php';
+
+type ApiCategoriesProps = {
+  trivia_categories: ApiCategoryProps[];
+}
+
+export const getCategories: () => Promise<ApiCategoriesProps> = async (): Promise<ApiCategoriesProps> => {
+  const response = await fetch(CATEGORIES_API_URL);
+  return await response.json();
+}

--- a/src/api/getCategories.ts
+++ b/src/api/getCategories.ts
@@ -1,10 +1,6 @@
-import { ApiCategoryProps } from "../types/triviaApi";
+import { ApiCategoriesProps } from "../types/triviaApi";
 
 const CATEGORIES_API_URL = 'https://opentdb.com/api_category.php';
-
-type ApiCategoriesProps = {
-  trivia_categories: ApiCategoryProps[];
-}
 
 export const getCategories: () => Promise<ApiCategoriesProps> = async (): Promise<ApiCategoriesProps> => {
   const response = await fetch(CATEGORIES_API_URL);

--- a/src/api/getQuestions.ts
+++ b/src/api/getQuestions.ts
@@ -6,9 +6,11 @@ const QUESTIONS_API_URL = 'https://opentdb.com/api.php';
 export const getQuestions: (query: QueryProps) => Promise<ApiDataProps> = async (query: QueryProps): Promise<ApiDataProps> => {
   let searchParams = new URLSearchParams();
   if (query) {
-    Object.keys(query).forEach((queryKey) => {
-      // @ts-ignore
-      searchParams.set(queryKey, query[queryKey].toString());
+    (Object.keys(query) as (keyof QueryProps)[]).forEach((queryKey) => {
+      const value = query[queryKey];
+      if (value !== null && value !== undefined) {
+        searchParams.set(queryKey, value.toString());
+      }
     });
   }
   const response = await fetch(`${ QUESTIONS_API_URL }?${searchParams}`);

--- a/src/api/getQuestions.ts
+++ b/src/api/getQuestions.ts
@@ -1,8 +1,16 @@
 import type { ApiDataProps } from "../types/triviaApi";
+import { QueryProps } from "../types/queryOptions";
 
-const API_URL = 'https://opentdb.com/api.php?amount=10&category=17';
+const QUESTIONS_API_URL = 'https://opentdb.com/api.php';
 
-export const getQuestions: () => Promise<ApiDataProps> = async (): Promise<ApiDataProps> => {
-  const response = await fetch(API_URL);
+export const getQuestions: (query: QueryProps) => Promise<ApiDataProps> = async (query: QueryProps): Promise<ApiDataProps> => {
+  let searchParams = new URLSearchParams();
+  if (query) {
+    Object.keys(query).forEach((queryKey) => {
+      // @ts-ignore
+      searchParams.set(queryKey, query[queryKey].toString());
+    });
+  }
+  const response = await fetch(`${ QUESTIONS_API_URL }?${searchParams}`);
   return await response.json();
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,16 @@
 import React, { ComponentPropsWithoutRef } from "react";
 
-type ButtonProps =  ComponentPropsWithoutRef<'button'>;
+type ButtonProps =  ComponentPropsWithoutRef<'button'> & {
+  variant?: 'primary' | 'secondary';
+}
 
 function Button(props: ButtonProps) {
-  const { children, disabled, ...rest } = props;
+  const { children, disabled, variant = 'primary', ...rest } = props;
+  const buttonColor = disabled ? 'bg-grey-200' : variant === 'secondary' ? 'bg-red-500' : 'bg-primary-500';
+
   return (
     <button
-      className={ `w-fit py-2 px-4 rounded-minimal text-white ${ disabled ? 'bg-grey-200' : 'bg-green-700'}` }
+      className={ `w-fit py-2 px-4 rounded-minimal text-white ${ buttonColor }` }
       disabled={disabled}
       {...rest}
     >

--- a/src/components/QuestionsList/QuestionsList.tsx
+++ b/src/components/QuestionsList/QuestionsList.tsx
@@ -12,6 +12,7 @@ type QuestionDataProps = {
   setAnswers: Dispatch<SetStateAction<AnswerProps[]>>,
   isFormSubmitted: boolean,
   setIsFormSubmitted: Dispatch<SetStateAction<boolean>>
+  enabled: boolean,
 }
 
 function QuestionsList(props: QuestionDataProps) {
@@ -20,7 +21,8 @@ function QuestionsList(props: QuestionDataProps) {
     isFormSubmitted,
     setIsFormSubmitted,
     answers,
-    setAnswers
+    setAnswers,
+    enabled
   } = props;
 
   const { isLoading, isFetching, error, data } = response ?? {};
@@ -37,7 +39,7 @@ function QuestionsList(props: QuestionDataProps) {
   const isFormFilled = answers.length === questions.length;
   const errorMessage = error?.message || "Something went wrong. Please try again.";
 
-  if (isLoading || isFetching) return <span className="loader"></span>;
+  if (isLoading || isFetching || !enabled) return <span className="loader"></span>;
   if (exceedRequestsNr) return <span>Too many requests have occurred. Wait 5 seconds and try again.</span>;
   if (error) return <span>{`An error has occurred: ${errorMessage}`}</span>;
 

--- a/src/components/QuestionsList/QuestionsList.tsx
+++ b/src/components/QuestionsList/QuestionsList.tsx
@@ -1,10 +1,11 @@
 import React, { Dispatch, FormEvent, SetStateAction, useMemo } from "react";
 import Question from "../Question/Question";
 import Button from "../Button/Button";
-import { ApiDataProps } from "../../types/triviaApi";
 import { UseQueryResult } from "@tanstack/react-query";
-import { AnswerProps } from "../../types/answer";
+import type { ApiDataProps } from "../../types/triviaApi";
+import type { AnswerProps } from "../../types/answer";
 import { hasExceededRequestLimit } from "../../utils/hasExceededRequestLimit";
+import { Skeleton } from "@mui/material";
 
 type QuestionDataProps = {
   response?:  UseQueryResult<ApiDataProps, Error>,
@@ -39,9 +40,11 @@ function QuestionsList(props: QuestionDataProps) {
   const isFormFilled = answers.length === questions.length;
   const errorMessage = error?.message || "Something went wrong. Please try again.";
 
-  if (isLoading || isFetching || !enabled) return <span className="loader"></span>;
+  const loading = isLoading || isFetching || !enabled;
+
   if (exceedRequestsNr) return <span>Too many requests have occurred. Wait 5 seconds and try again.</span>;
   if (error) return <span>{`An error has occurred: ${errorMessage}`}</span>;
+  if (data?.results.length === 0) return <span>There are no questions for the selected options you made</span>;
 
   return (
     <>
@@ -49,7 +52,9 @@ function QuestionsList(props: QuestionDataProps) {
         onSubmit={ onHandleSubmit }
         className="w-full flex flex-col space-y-4"
       >
-        { questions?.map((question, index) =>
+        {loading ? [ ...Array(5) ].map((_, i) => (
+          <QuestionSkeleton key={`question-skeleton-${i}`}/>
+         )) : questions?.map((question, index) =>
           <Question
             key={ question.question }
             questionId={ `question-${ index + 1 }` }
@@ -58,6 +63,7 @@ function QuestionsList(props: QuestionDataProps) {
             setAnswers={setAnswers}
           />
         ) }
+        <QuestionSkeleton/>
         <Button disabled={ !isFormFilled }>Submit</Button>
       </form>
       <span className="text-red-600 pb-6 mb-6">{ isFormSubmitted ? `${ countCorrectAnswers } / 10 correct` : ''}</span>
@@ -66,3 +72,23 @@ function QuestionsList(props: QuestionDataProps) {
 }
 
 export default QuestionsList;
+
+const QuestionSkeleton = () => {
+  return (
+    <div className='flex flex-col space-y-2 rounded-mobile md:rounded-desktop bg-grey-100 p-6 shadow-elevation-01 w-full'>
+      <div className="flex flex-col space-y-4">
+        <Skeleton sx={ { height: 20, width: "80%" } } animation="wave" variant="rectangular"/>
+        <ul className="w-full flex flex-col gap-2.5">
+          { [ ...Array(5) ].map((_, i) => (
+            <li className="flex" key={ `option-skeleton-${ i }` }>
+              <span className="flex gap-2 items-center w-full">
+                <Skeleton sx={ {height: 20, width: 20} } animation="wave" variant="circular"/>
+                <Skeleton sx={ {height: 20, width: `${20 - i}%`} } animation="wave" variant="rectangular"/>
+              </span>
+            </li>
+          )) }
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/QuestionsList/__test__/QuestionsList.test.tsx
+++ b/src/components/QuestionsList/__test__/QuestionsList.test.tsx
@@ -8,5 +8,6 @@ test("should render <QuestionsList> without props", () => {
       setAnswers={() => {}}
       isFormSubmitted={false}
       setIsFormSubmitted={() => {}}
+      enabled={true}
     />);
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,0 +1,34 @@
+import { FormControl, MenuItem, Select as SelectMUI } from "@mui/material";
+import React from "react";
+import type { CategoryProps } from "../../types/triviaApi";
+
+type SelectProps = {
+  id: string;
+  onChange: (e: any) => void;
+  value: string;
+  options: CategoryProps[];
+  label?: string;
+}
+
+export default function Select({ id, onChange, value, options, label }: SelectProps) {
+  return (
+    <FormControl size="small">
+      <div className="flex gap-2 items-center">
+        <span>{ label }</span>
+        <SelectMUI
+          labelId={ id }
+          id={ id }
+          value={ value }
+          onChange={ onChange }
+          size="small"
+        >
+          { options.map((option) => (
+            <MenuItem key={ option.id } value={ option.id }>
+              { option.name }
+            </MenuItem>
+          )) }
+        </SelectMUI>
+      </div>
+    </FormControl>
+);
+}

--- a/src/components/ToggleSelector/ToggleSelector.tsx
+++ b/src/components/ToggleSelector/ToggleSelector.tsx
@@ -1,0 +1,37 @@
+import React, { useId } from "react";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+
+type ToggleSelectorProps = {
+  value: string | number | null;
+  onChange: (e: any) => void;
+  options: any[];
+  label?: string;
+  exclusive?: boolean;
+}
+
+export default function ToggleSelector({ value, onChange, options, label, exclusive=true }: ToggleSelectorProps) {
+  const id = useId();
+
+  return (
+    <div className="flex gap-2 items-center">
+      <span>{label}</span>
+      <ToggleButtonGroup
+        color="primary"
+        value={ value }
+        exclusive={ exclusive }
+        onChange={ onChange }
+      >
+        { options?.map(option => (
+          <ToggleButton
+            key={ id }
+            id={ id }
+            value={ option.value }
+            selected={ value === option.value }
+          >
+            { option.name }
+          </ToggleButton>
+        )) }
+      </ToggleButtonGroup>
+    </div>
+  );
+}

--- a/src/components/ToggleSelector/ToggleSelector.tsx
+++ b/src/components/ToggleSelector/ToggleSelector.tsx
@@ -16,6 +16,7 @@ export default function ToggleSelector({ value, onChange, options, label, exclus
     <div className="flex gap-2 items-center">
       <span>{label}</span>
       <ToggleButtonGroup
+        size="small"
         color="primary"
         value={ value }
         exclusive={ exclusive }

--- a/src/constants/query.ts
+++ b/src/constants/query.ts
@@ -1,3 +1,5 @@
+import type { QueryProps } from "../types/queryOptions";
+
 export const AMOUNT_OPTIONS = [
   { value: '10', name: '10' },
   { value: '20', name: '20' },
@@ -14,3 +16,5 @@ export const TYPE_OPTIONS = [
   { value: 'multiple', name: 'multiple' },
   { value: 'boolean', name: 'boolean' },
 ];
+
+export const INITIAL_QUERY_VALUE: QueryProps = { amount: '10', category: '17', type: '', difficulty: '' };

--- a/src/constants/query.ts
+++ b/src/constants/query.ts
@@ -1,0 +1,16 @@
+export const AMOUNT_OPTIONS = [
+  { value: '10', name: '10' },
+  { value: '20', name: '20' },
+  { value: '50', name: '50' },
+];
+
+export const DIFFICULTY_OPTIONS = [
+  { value: 'easy', name: 'easy' },
+  { value: 'medium', name: 'medium' },
+  { value: 'hard', name: 'hard' },
+];
+
+export const TYPE_OPTIONS = [
+  { value: 'multiple', name: 'multiple' },
+  { value: 'boolean', name: 'boolean' },
+];

--- a/src/modules/CustomiseTriviaForm/CustomiseTriviaForm.tsx
+++ b/src/modules/CustomiseTriviaForm/CustomiseTriviaForm.tsx
@@ -1,0 +1,91 @@
+import Button from "../../components/Button/Button";
+import ToggleSelector from "../../components/ToggleSelector/ToggleSelector";
+import { AMOUNT_OPTIONS, DIFFICULTY_OPTIONS, INITIAL_QUERY_VALUE, TYPE_OPTIONS } from "../../constants/query";
+import Select from "../../components/Select/Select";
+import React, { Dispatch, FormEvent } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ApiCategoriesProps } from "../../types/triviaApi";
+import { getCategories } from "../../api/getCategories";
+import type { SelectChangeEvent } from "@mui/material";
+import { QueryProps } from "../../types/queryOptions";
+
+type CustomiseTriviaFormProps = {
+  setQuery: Dispatch<React.SetStateAction<QueryProps>>;
+  setTempQuery: Dispatch<React.SetStateAction<QueryProps>>;
+  tempQuery: QueryProps;
+  setOpenCustomizationOptions: Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function CustomiseTriviaForm( props: CustomiseTriviaFormProps ) {
+  const { setQuery, tempQuery, setTempQuery, setOpenCustomizationOptions } = props;
+
+  const { data: categoriesData } = useQuery<ApiCategoriesProps>({
+    queryKey: ['questionCategories'],
+    queryFn: getCategories,
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement> | SelectChangeEvent<string>, key: string) => {
+    setTempQuery({ ...tempQuery, [key]: e.target.value });
+  };
+
+  const handleCategoryChange = (e: SelectChangeEvent<string>) => {
+    setTempQuery({ ...tempQuery, category: e.target.value });
+  };
+
+  const handleConfirmSelections = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setQuery({ ...tempQuery });
+  };
+
+  const resetSelections = () => {
+    setTempQuery({ ...INITIAL_QUERY_VALUE });
+  };
+
+  return (
+    <form onSubmit={ handleConfirmSelections } className="flex flex-col justify-between w-full bg-white p-4">
+      <div className="flex w-full justify-between items-center h-12 border-b-grey-200 border-b">
+        <h2 className="capitalize font-bold text-20">Customise your trivia</h2>
+        <Button onClick={ () => setOpenCustomizationOptions(false) }>close</Button>
+      </div>
+      <div className="flex flex-col justify-between w-full pt-4 space-y-4">
+        <div className="flex justify-between w-full">
+          <ToggleSelector
+            value={ tempQuery.amount }
+            options={ AMOUNT_OPTIONS }
+            onChange={ e => handleChange(e, 'amount') }
+            label="Quantity:"
+          />
+          <ToggleSelector
+            value={ tempQuery.difficulty }
+            options={ DIFFICULTY_OPTIONS }
+            exclusive={ false }
+            onChange={ e => handleChange(e, 'difficulty') }
+            label="Difficulty:"
+          />
+        </div>
+        <div className="flex justify-between w-full">
+          <ToggleSelector
+            value={ tempQuery.type }
+            options={ TYPE_OPTIONS }
+            onChange={ e => handleChange(e, 'type') }
+            label="Types:"
+          />
+
+          { categoriesData ? (
+            <Select
+              id="category-selector"
+              value={ tempQuery.category }
+              options={ categoriesData?.trivia_categories }
+              onChange={ handleCategoryChange }
+              label="Category:"
+            />
+           ) : null }
+        </div>
+        <div className="flex gap-4 w-full">
+          <Button type="submit">Generate Trivia!</Button>
+          <Button onClick={ resetSelections } variant="secondary">Reset selections</Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/types/queryOptions.ts
+++ b/src/types/queryOptions.ts
@@ -1,0 +1,8 @@
+import type { DifficultyEnum, TypeEnum } from "./triviaApi";
+
+export type QueryProps = {
+  amount: string | number | null;
+  category: string;
+  difficulty: DifficultyEnum | string;
+  type: TypeEnum | string;
+}

--- a/src/types/triviaApi.ts
+++ b/src/types/triviaApi.ts
@@ -15,11 +15,11 @@ export type QuestionDataProps = {
   incorrect_answers: string[];
 }
 
-export type ApiCategoryProps = {
+export type CategoryProps = {
   id: number;
   name: string;
 }
 
 export type ApiCategoriesProps = {
-  trivia_categories: ApiCategoryProps[];
+  trivia_categories: CategoryProps[];
 }

--- a/src/types/triviaApi.ts
+++ b/src/types/triviaApi.ts
@@ -3,8 +3,8 @@ export type ApiDataProps = {
   results: QuestionDataProps[];
 }
 
-type TypeEnum = "multiple" | "boolean";
-type DifficultyEnum = "easy" | "medium" | "hard";
+export type TypeEnum = "multiple" | "boolean";
+export type DifficultyEnum = "easy" | "medium" | "hard";
 
 export type QuestionDataProps = {
   type: TypeEnum;
@@ -13,4 +13,13 @@ export type QuestionDataProps = {
   question: string;
   correct_answer: string;
   incorrect_answers: string[];
+}
+
+export type ApiCategoryProps = {
+  id: number;
+  name: string;
+}
+
+export type ApiCategoriesProps = {
+  trivia_categories: ApiCategoryProps[];
 }

--- a/src/utils/delayFunctionCall.ts
+++ b/src/utils/delayFunctionCall.ts
@@ -1,0 +1,5 @@
+export function delayFunctionCall(fn: () => void) {
+  setTimeout(() => {
+    fn();
+  }, 5000);
+}


### PR DESCRIPTION
## What was done:
- added materialUI and related libraries
- create a "QuestionSkeleton" and display it wile fetching the data from the api
- created hook and functions to fetch questions categories
- workaround the "exceed request limit" limitation from the api
- created a form where the user can customise the trivia by choosing:
   * the number of questions (20, 30 or 50),
   * type ("multiple" or "boolean")
   * category
   * difficulty ("easy", "medium" or "hard")

## Screenshot
![image](https://github.com/user-attachments/assets/5b8235e8-7183-451d-b627-424fa1e2f537)
